### PR TITLE
Make buttons 48px

### DIFF
--- a/sass/_size.scss
+++ b/sass/_size.scss
@@ -6,7 +6,7 @@ $normal-gap: 0.4rem;
 $large-gap: 0.8rem;
 $huge-gap: 1.6rem;
 
-$icon-size: 1.5rem;
+$icon-size: 1.6rem;
 $small-icon-size: 0.75rem;
 
 @mixin padded {

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -7,7 +7,7 @@
 {{ image.static_path | trim_start_matches(pat="static") | safe }}
 {%- endmacro resizedimage -%}
 
-{%- macro image(path, width) -%}
+{%- macro image(path, width, class="") -%}
 {%- set meta = get_image_metadata(path=path) -%}
 {%- set height = meta.height * width / meta.width | round | int -%}
 {%- set source = path | replace(from=".jpg", to=".webp") -%}
@@ -17,7 +17,7 @@
   {{ macros::resizedimage(path=source, width=width*2, height=height*2) }} 2x,
   {{ macros::resizedimage(path=source, width=width*3, height=height*3) }} 3x,
   {{ macros::resizedimage(path=source, width=width*4, height=height*4) }} 4x" type="image/webp">
-  <img src="{{ path | safe }}" alt="{{ macros::titlefrompath(path=path) }}" width="{{ width }}" height="{{ height }}" >
+  <img src="{{ path | safe }}"  {% if class -%} class="{{ class }}"{%- endif -%} alt="{{ macros::titlefrompath(path=path) }}" width="{{ width }}" height="{{ height }}" >
 </picture>
 {%- endmacro image -%}
 

--- a/tests/lighthouserc.live.cjs
+++ b/tests/lighthouserc.live.cjs
@@ -13,8 +13,7 @@ module.exports = {
         "categories:performance": ["error", { minScore: 0.9 }],
         "categories:accessibility": ["error", { minScore: 1 }],
         "categories:best-practices": ["error", { minScore: 1 }],
-        // TODO: #75 Fix tap target sizes
-        "categories:seo": ["error", { minScore: 0.95 }],
+        "categories:seo": ["error", { minScore: 1 }],
       },
     },
     upload: {


### PR DESCRIPTION
Fixes #75

Buttons were 46px before. This passes the tap target test in Lighthouse (#74).